### PR TITLE
Fix composer plugin api requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.6",
         "apishka/cs": "~1.0.0",
-        "composer-plugin-api": "~1.0.0",
+        "composer-plugin-api": "^1.0.0",
         "symfony/finder": "~2.7.0",
         "symfony/console": "~2.7.0",
         "doctrine/cache": "~1.4.0"


### PR DESCRIPTION
Without this patch if we bump the composer plugin API to 1.1+ your plugin won't be installable anymore.
